### PR TITLE
Fix AsyncPlayerPreLoginEvent not passing to TNE (Java SE / OpenJDK 11+)

### DIFF
--- a/TNE/pom.xml
+++ b/TNE/pom.xml
@@ -99,6 +99,12 @@
     </repositories>
 
     <dependencies>
+        <!-- Part of Java EE, removed from Java SE in JDK11 -->
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+        </dependency>
         <dependency>
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>


### PR DESCRIPTION
The issue stems from a missing class in Java SE that was deprecated in Java SE 9 and later removed in Java SE 11. The class is actually meant for Java EE, but is available in Maven's Central Repository.

#### Before
![TNE ERR](https://user-images.githubusercontent.com/2712890/58453701-c0135480-80e1-11e9-821e-1d0f40f6e2bb.PNG)
#### After
![TNE ERR-fix](https://user-images.githubusercontent.com/2712890/58453812-0cf72b00-80e2-11e9-9801-9144237034ca.PNG)
