### PR TITLE
Transaction permission changes

### DIFF
--- a/TNE/src/net/tnemc/core/commands/transaction/TransactionHistoryCommand.java
+++ b/TNE/src/net/tnemc/core/commands/transaction/TransactionHistoryCommand.java
@@ -71,7 +71,7 @@ public class TransactionHistoryCommand extends TNECommand {
       return false;
     }
 
-    if(parsed.containsKey("player") && sender.hasPermission("tne.transactions.historyother")) {
+    if(parsed.containsKey("player") && sender.hasPermission("tne.transactions.history.other")) {
       if(Bukkit.getPlayer(parsed.get("player")) != null) {
         player = Bukkit.getPlayer(parsed.get("player"));
       }

--- a/TNE/src/net/tnemc/resources/plugin.yml
+++ b/TNE/src/net/tnemc/resources/plugin.yml
@@ -278,20 +278,24 @@ permissions:
             tne.transaction: true
             tne.transaction.away: true
             tne.transaction.history: true
+            tne.transaction.history.other: true
             tne.transaction.info: true
             tne.transaction.void: true
     tne.transaction:
         description: Allows use of the transaction command.
-        default: op
+        default: true
     tne.transaction.away:
         description: Allows viewing a list of transactions that happened while offline.
-        default: op
+        default: true
     tne.transaction.history:
+        description: Allows viewing any player's transaction history.
+        default: true
+    tne.transaction.history.other:
         description: Allows viewing any player's transaction history.
         default: op
     tne.transaction.info:
         description: Allows viewing details on any transaction.
-        default: op
+        default: true
     tne.transaction.void:
         description: Allows undoing a completed transaction.
         default: op


### PR DESCRIPTION
Turns out the transaction history perms are already split! It's just not documented (PR coming). This just renames it and declares it in the plugin.yml file, and changes the default permissions for transaction commands.