### PR TITLE
Remove obsolete permission node tne.general.mob

### DIFF
--- a/TNE/src/net/tnemc/resources/plugin.yml
+++ b/TNE/src/net/tnemc/resources/plugin.yml
@@ -26,9 +26,6 @@ permissions:
     tne.bypass.world:
         description: Allows bypassing of any configured world changing costs.
         default: false
-    tne.general.mob:
-        description: Allows receiving mob rewards.
-        default: true
     tne.menu.*:
         description: Grants full access to the TNE Action Menu.
         children:


### PR DESCRIPTION
This was replaced by `tne.mobs.rewards`.