### PR TITLE
fix for /money and /balance command when running from console with no args.

### DIFF
--- a/TNE/src/net/tnemc/core/commands/money/MoneyBalanceCommand.java
+++ b/TNE/src/net/tnemc/core/commands/money/MoneyBalanceCommand.java
@@ -16,6 +16,7 @@ import net.tnemc.core.economy.transaction.charge.TransactionCharge;
 import net.tnemc.core.economy.transaction.result.TransactionResult;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -76,6 +77,7 @@ public class MoneyBalanceCommand extends TNECommand {
   @Override
   public boolean execute(CommandSender sender, String command, String[] arguments) {
     Bukkit.getScheduler().runTaskAsynchronously(plugin, ()->{
+
       TNE.debug("===START MoneyBalanceCommand  ===");
       String world = (arguments.length >= 1)? arguments[0] : WorldFinder.getWorld(sender, WorldVariant.BALANCE);
       if(TNE.instance().getWorldManager(world) == null) world = WorldFinder.getWorld(sender, WorldVariant.BALANCE);
@@ -86,6 +88,11 @@ public class MoneyBalanceCommand extends TNECommand {
       if(TNE.manager().currencyManager() == null) TNE.debug("TNECurrency Manager is null");
       if(TNE.manager().currencyManager().get(world) == null) TNE.debug("World TNECurrency is null");
       String currencyName = (arguments.length >= 2)? arguments[1] : TNE.manager().currencyManager().get(world).name();
+
+      if(sender instanceof Player == false && arguments.length == 0){
+        new Message("Messages.General.IsConsole");
+        return;
+      }
 
       if(arguments.length < 2) {
         currencyName = MISCUtils.findCurrencyName(world, Bukkit.getPlayer(id).getLocation());

--- a/TNE/src/net/tnemc/resources/messages.yml
+++ b/TNE/src/net/tnemc/resources/messages.yml
@@ -47,6 +47,7 @@ Messages:
        Saved: "<yellow>Successfully saved all TNE Data!"
        NoPlayer: "<red>Unable to locate player \"$player\"!"
        Disabled: "<red>Economy features are currently disabled in this world!"
+       IsConsole: "<red>You can not run this command as in the console!"
 
     Item:
       Invalid: "<red>Invalid item name and/or durability combination entered."


### PR DESCRIPTION
Added check for /money command which returned the below error when running /money or /balance from console.

[TheNewEconomy] Plugin TheNewEconomy v0.1.1.8 generated an exception while executing task 13876
java.lang.NullPointerException: null
        at net.tnemc.core.commands.money.MoneyBalanceCommand.lambda$execute$1(MoneyBalanceCommand.java:91) ~[?:?]
        at org.bukkit.craftbukkit.v1_14_R1.scheduler.CraftTask.run(CraftTask.java:81) ~[spigot-1.14.4.jar:git-Spigot-8887c5f-06efc9e]
        at org.bukkit.craftbukkit.v1_14_R1.scheduler.CraftAsyncTask.run(CraftAsyncTask.java:54) [spigot-1.14.4.jar:git-Spigot-8887c5f-06efc9e]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_222]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_222]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_222]