### PR TITLE
Truncate numbers with excess decimals

### DIFF
--- a/TNE/src/net/tnemc/core/common/currency/ItemCalculations.java
+++ b/TNE/src/net/tnemc/core/common/currency/ItemCalculations.java
@@ -133,7 +133,7 @@ public class ItemCalculations {
       boolean add = (consolidate) || amount.compareTo(old) >= 0;
       if(remove) add = false;
 
-      if(consolidate) split = (amount.toPlainString() + (amount.toPlainString().contains(".")? "" : "0.00")).split("\\.");
+      if(consolidate) split = (amount.toPlainString() + (amount.toPlainString().contains(".")? "" : ".00")).split("\\.");
 
       // Get a string that is exactly as long as there are decimal points.
       final String truncatedMinor =

--- a/TNE/src/net/tnemc/core/common/currency/ItemCalculations.java
+++ b/TNE/src/net/tnemc/core/common/currency/ItemCalculations.java
@@ -19,6 +19,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -132,13 +133,21 @@ public class ItemCalculations {
       boolean add = (consolidate) || amount.compareTo(old) >= 0;
       if(remove) add = false;
 
-      if(consolidate) split = (amount.toPlainString() + (amount.toPlainString().contains(".")? "" : ".00")).split("\\.");
+      if(consolidate) split = (amount.toPlainString() + (amount.toPlainString().contains(".")? "" : "0.00")).split("\\.");
+
+      // Get a string that is exactly as long as there are decimal points.
+      final String truncatedMinor =
+              // make it longer
+              (split[1] + String.join("",
+                      Collections.nCopies(Math.max(0, currency.getDecimalPlaces() - split[1].length()), "0")))
+                      // make it shorter
+                      .substring(0, currency.getDecimalPlaces());
 
       if(consolidate) clearItems(currency, inventory);
       BigInteger majorChange = (consolidate)? setMajorConsolidate(account, currency, new BigInteger(split[0]), inventory) :
           setMajor(account, currency, new BigInteger(split[0]), add, inventory);
-      BigInteger minorChange = (consolidate)? setMinorConsolidate(account, currency, new BigInteger(split[1]), inventory) :
-          setMinor(account, currency, new BigInteger(split[1]), add, inventory);
+      BigInteger minorChange = (consolidate)? setMinorConsolidate(account, currency, new BigInteger(truncatedMinor), inventory) :
+          setMinor(account, currency, new BigInteger(truncatedMinor), add, inventory);
 
       TNE.debug("MajorChange: " + majorChange.toString());
       TNE.debug("MinorChange: " + minorChange.toString());

--- a/TNE/src/net/tnemc/core/common/currency/formatter/CurrencyFormatter.java
+++ b/TNE/src/net/tnemc/core/common/currency/formatter/CurrencyFormatter.java
@@ -17,6 +17,7 @@ import org.bukkit.Location;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 
 /**
@@ -107,7 +108,14 @@ public class CurrencyFormatter {
   private static BigDecimal parseWeight(TNECurrency currency, BigDecimal decimal) {
     String[] amountStr = (decimal.toPlainString() + (decimal.toPlainString().contains(".")? "" : ".00")).split("\\.");
     BigInteger major = new BigInteger(amountStr[0]);
-    BigInteger minor = new BigInteger(String.format("%-" + currency.getDecimalPlaces() + "s", amountStr[1]).replace(' ', '0'));
+    // Get a string that is exactly as long as there are decimal points.
+    final String truncatedMinor =
+            // make it longer
+            (amountStr[1] + String.join("",
+                    Collections.nCopies(Math.max(0, currency.getDecimalPlaces() - amountStr[1].length()), "0")))
+            // make it shorter
+            .substring(0, currency.getDecimalPlaces());
+    BigInteger minor = new BigInteger(truncatedMinor);
     BigInteger majorConversion = minor;
     majorConversion = majorConversion.divide(new BigInteger(currency.getMinorWeight() + ""));
     major = major.add(majorConversion);


### PR DESCRIPTION
Fixes #409 by truncating numbers that exceed the amount of decimals for a number. 