### PR TITLE
IMPORTANT Choose the right currency for removing holdings

### DIFF
--- a/TNE/src/net/tnemc/core/common/account/TNEAccount.java
+++ b/TNE/src/net/tnemc/core/common/account/TNEAccount.java
@@ -473,7 +473,7 @@ public class TNEAccount implements Account {
   @Override
   public EconomyResponse removeHoldings(BigDecimal amount, Currency currency) {
     if(amount.equals(BigDecimal.ZERO)) return GeneralResponse.SUCCESS;
-    if(hasHoldings(amount)) {
+    if(hasHoldings(amount, currency)) {
       String world = TNE.instance().defaultWorld;
       removeHoldings(amount, world, currency.name(), false);
       return GeneralResponse.SUCCESS;
@@ -484,7 +484,7 @@ public class TNEAccount implements Account {
   @Override
   public EconomyResponse removeHoldings(BigDecimal amount, Currency currency, String world) {
     if(amount.equals(BigDecimal.ZERO)) return GeneralResponse.SUCCESS;
-    if(hasHoldings(amount)) {
+    if(hasHoldings(amount, currency)) {
       removeHoldings(amount, world, currency.name(), false);
       return GeneralResponse.SUCCESS;
     }


### PR DESCRIPTION
This is an important bug to fix. Currently, when you try to create a TransactionCharge for a non-default currency, the plugin will check the requested amount against your default currency holding instead of the requested currency holding which result in incorrect check of the player balance. 
It creates bug in plugins using the TransactionCharge class where players can buy anything they want if they have enough default currency, even though they have 0 secondary currency and should not be able to.